### PR TITLE
Fix entity list accessors

### DIFF
--- a/src/main/java/seedu/address/experimental/model/Model.java
+++ b/src/main/java/seedu/address/experimental/model/Model.java
@@ -92,6 +92,15 @@ public interface Model {
      */
     void resetFilteredEntityList();
 
+    /** Set filtered list to items only */
+    void listItems();
+
+    /** Set filtered list to characters only */
+    void listCharacters();
+
+    /** Set filtered list to mobs only */
+    void listMobs();
+
     // =============== Edit mode ===================
     /**
      * Sets the current selected entity

--- a/src/main/java/seedu/address/experimental/model/Model.java
+++ b/src/main/java/seedu/address/experimental/model/Model.java
@@ -76,6 +76,7 @@ public interface Model {
      */
     void setEntity(Entity target, Entity editedEntity);
 
+    // ============== Filtered entity list =================
     /** Returns an unmodifiable view of the filtered entity list */
     ObservableList<Entity> getFilteredEntityList();
 
@@ -84,5 +85,22 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredEntityList(Predicate<Entity> predicate);
+
+    /**
+     * Resets filtered entity list back to all entities
+     * Can be used before tag/name find function
+     */
+    void resetFilteredEntityList();
+
+    // =============== Edit mode ===================
+    /**
+     * Sets the current selected entity
+     */
+    void setCurrentSelectedEntity(Entity newSelection);
+
+    /**
+     * Returns the current selected entity
+     */
+    Entity getCurrentSelectedEntity();
 
 }

--- a/src/main/java/seedu/address/experimental/model/ModelManager.java
+++ b/src/main/java/seedu/address/experimental/model/ModelManager.java
@@ -154,6 +154,25 @@ public class ModelManager implements Model {
         } else {
         }
     }
+    // =========== List operations
+
+    @Override
+    public void listItems() {
+        filteredActive = filteredItems;
+        updateFilteredEntityList(PREDICATE_SHOW_ALL_ENTITIES);
+    }
+
+    @Override
+    public void listCharacters() {
+        filteredActive = filteredCharacters;
+        updateFilteredEntityList(PREDICATE_SHOW_ALL_ENTITIES);
+    }
+
+    @Override
+    public void listMobs() {
+        filteredActive = filteredMobs;
+        updateFilteredEntityList(PREDICATE_SHOW_ALL_ENTITIES);
+    }
 
     //=========== Filtered Entity List Accessors ==========================================================//
 
@@ -171,6 +190,7 @@ public class ModelManager implements Model {
     @Override
     public void resetFilteredEntityList() {
         filteredActive = filteredAllEntities;
+        updateFilteredEntityList(PREDICATE_SHOW_ALL_ENTITIES);
     }
 
     // ============= Edit Mode ==================

--- a/src/main/java/seedu/address/experimental/model/ModelManager.java
+++ b/src/main/java/seedu/address/experimental/model/ModelManager.java
@@ -11,7 +11,10 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.entity.Character;
 import seedu.address.model.entity.Entity;
+import seedu.address.model.entity.Item;
+import seedu.address.model.entity.Mob;
 
 /**
  * Represents the in-memory model of the Reroll data.
@@ -21,12 +24,17 @@ public class ModelManager implements Model {
 
     private final Reroll reroll;
     private final UserPrefs userPrefs;
-    private final FilteredList<Entity> filteredEntities;
+    private final FilteredList<Entity> filteredAllEntities;
+    private final FilteredList<Entity> filteredItems;
+    private final FilteredList<Entity> filteredMobs;
+    private final FilteredList<Entity> filteredCharacters;
+    // Placeholder for the active list.
+    private FilteredList<Entity> filteredActive;
+    private Entity active = null;
 
     /**
      * Initializes a ModelManager with the given reroll and userPrefs.
      */
-
     public ModelManager(ReadOnlyReroll reroll, ReadOnlyUserPrefs userPrefs) {
         requireAllNonNull(reroll, userPrefs);
 
@@ -36,9 +44,12 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         // Meaningless to maintain generics at this point.
         // Don't want any generics outside of this model.
-        @SuppressWarnings("unchecked")
-        FilteredList<Entity> temp = (FilteredList<Entity>) new FilteredList<>(this.reroll.getList());
-        this.filteredEntities = temp;
+        this.filteredCharacters = (FilteredList<Entity>) new FilteredList<>(this.reroll.getCharacterList());
+        this.filteredItems = (FilteredList<Entity>) new FilteredList<>(this.reroll.getItemList());
+        this.filteredMobs = (FilteredList<Entity>) new FilteredList<>(this.reroll.getMobList());
+        this.filteredAllEntities = new FilteredList<>(this.reroll.getAllList());
+        // By default, the active list is all entities.
+        this.filteredActive = this.filteredAllEntities;
     }
 
     public ModelManager() {
@@ -101,30 +112,80 @@ public class ModelManager implements Model {
     @Override
     public void addEntity(Entity entity) {
         requireNonNull(entity);
-        reroll.addEntity(entity);
+        if (entity instanceof Item) {
+            reroll.addItem((Item) entity);
+            filteredActive = filteredItems;
+        } else if (entity instanceof Character) {
+            reroll.addCharacter((Character) entity);
+            filteredActive = filteredCharacters;
+        } else if (entity instanceof Mob) {
+            reroll.addMob((Mob) entity);
+            filteredActive = filteredMobs;
+        }
         updateFilteredEntityList(PREDICATE_SHOW_ALL_ENTITIES);
     }
 
     @Override
-    public void deleteEntity(Entity entity) {
-        reroll.deleteEntity(entity);
+    public void deleteEntity(Entity key) {
+        requireNonNull(key);
+        if (key instanceof Item) {
+            reroll.deleteItem((Item) key);
+        } else if (key instanceof Character) {
+            reroll.deleteCharacter((Character) key);
+        } else if (key instanceof Mob) {
+            reroll.deleteMob((Mob) key);
+        } else {
+
+        }
     }
 
     @Override
     public void setEntity(Entity target, Entity edited) {
-        reroll.setEntity(target, edited);
+        requireAllNonNull(target, edited);
+        if (!target.getClass().equals(edited.getClass())) {
+            return; // throw error.
+        }
+        if (target instanceof Item) {
+            reroll.setItem((Item) target, (Item) edited);
+        } else if (target instanceof Character) {
+            reroll.setCharacter((Character) target, (Character) edited);
+        } else if (target instanceof Mob) {
+            reroll.setMob((Mob) target, (Mob) edited);
+        } else {
+        }
     }
 
-    //=========== Filtered Entity List Accessors =============================================================
+    //=========== Filtered Entity List Accessors ==========================================================//
 
     @Override
     public ObservableList<Entity> getFilteredEntityList() {
-        return filteredEntities;
+        return filteredActive;
     }
 
     @Override
     public void updateFilteredEntityList(Predicate<Entity> predicate) {
         requireNonNull(predicate);
-        filteredEntities.setPredicate(predicate);
+        filteredActive.setPredicate(predicate);
     }
+    // Reset
+    @Override
+    public void resetFilteredEntityList() {
+        filteredActive = filteredAllEntities;
+    }
+
+    // ============= Edit Mode ==================
+
+    @Override
+    public void setCurrentSelectedEntity(Entity newSelection) {
+        this.active = newSelection;
+    }
+
+    @Override
+    public Entity getCurrentSelectedEntity() {
+        if (active == null) {
+            // Should throw some error.
+        }
+        return active;
+    }
+
 }

--- a/src/main/java/seedu/address/experimental/model/Reroll.java
+++ b/src/main/java/seedu/address/experimental/model/Reroll.java
@@ -17,11 +17,13 @@ public class Reroll implements ReadOnlyReroll {
     private final RerollCharacters characters;
     private final RerollItems items;
     private final RerollMobs mobs;
+    private final RerollAllEntities entities;
 
     {
         characters = new RerollCharacters();
         items = new RerollItems();
         mobs = new RerollMobs();
+        entities = new RerollAllEntities();
     }
 
     public Reroll() {}
@@ -45,6 +47,12 @@ public class Reroll implements ReadOnlyReroll {
         characters.resetData(newData.getCharacters());
         items.resetData(newData.getItems());
         mobs.resetData(newData.getMobs());
+
+        // Initialize all entities
+        entities.addAll(characters);
+        entities.addAll(items);
+        entities.addAll(mobs);
+
     }
 
     @Override
@@ -70,80 +78,104 @@ public class Reroll implements ReadOnlyReroll {
      * @return
      */
     public boolean hasEntity(Entity e) {
-        // Switch till it works
-        if (e instanceof Item) {
-            return items.hasEntity((Item) e);
-        } else if (e instanceof Character) {
-            return characters.hasEntity((Character) e);
-        } else if (e instanceof Mob) {
-            return mobs.hasEntity((Mob) e);
-        } else {
-            // Should throw error
-            return false;
-        }
+        return entities.hasEntity(e);
     }
 
     /**
-     * Add Entity
-     * @param e
+     * Add Item
      */
-    public void addEntity(Entity e) {
-        if (e instanceof Item) {
-            items.addEntity((Item) e);
-        } else if (e instanceof Character) {
-            characters.addEntity((Character) e);
-        } else if (e instanceof Mob) {
-            mobs.addEntity((Mob) e);
-        } else {
-
-        }
+    public void addItem(Item item) {
+        items.addEntity(item);
+        entities.addEntity(item);
     }
 
     /**
-     * Set Entity
-     * @param target
-     * @param edited
+     * Add Character
      */
-    public void setEntity(Entity target, Entity edited) {
-        if (!target.getClass().equals(edited.getClass())) {
-            return; // throw error.
-        }
-        if (target instanceof Item) {
-            items.setEntity((Item) target, (Item) edited);
-        } else if (target instanceof Character) {
-            characters.setEntity((Character) target, (Character) edited);
-        } else if (target instanceof Mob) {
-            mobs.setEntity((Mob) target, (Mob) edited);
-        } else {
-
-        }
+    public void addCharacter(Character character) {
+        characters.addEntity(character);
+        entities.addEntity(character);
     }
 
     /**
-     * Edit entity
-     * @param key
+     * Add Mob
      */
-    public void deleteEntity(Entity key) {
-        if (key instanceof Item) {
-            items.deleteEntity((Item) key);
-        } else if (key instanceof Character) {
-            characters.deleteEntity((Character) key);
-        } else if (key instanceof Mob) {
-            mobs.deleteEntity((Mob) key);
-        } else {
+    public void addMob(Mob mob) {
+        mobs.addEntity(mob);
+        entities.addEntity(mob);
+    }
 
-        }
+    /**
+     * Set Item
+     */
+    public void setItem(Item target, Item edited) {
+        items.setEntity(target, edited);
+        entities.setEntity(target, edited);
+    }
+
+    /**
+     * Set character
+     */
+    public void setCharacter(Character target, Character edited) {
+        characters.setEntity(target, edited);
+        entities.setEntity(target, edited);
+    }
+
+    /**
+     * Set Mob
+     */
+    public void setMob(Mob target, Mob edited) {
+        mobs.setEntity(target, edited);
+        entities.setEntity(target, edited);
+    }
+
+    /**
+     * Delete item
+     */
+    public void deleteItem(Item key) {
+        items.deleteEntity(key);
+        entities.deleteEntity(key);
+    }
+
+    /**
+     * Delete character
+     */
+    public void deleteCharacter(Character key) {
+        characters.deleteEntity(key);
+        entities.deleteEntity(key);
+    }
+
+    /**
+     * Delete Mob
+     */
+    public void deleteMob(Mob key) {
+        mobs.deleteEntity(key);
+        entities.deleteEntity(key);
     }
 
     // Misc ====================
+
     /**
-     * Return some list for the updated list
+     * Return list for the all entities in
      * @return
      */
-    public ObservableList<? extends Entity> getList() {
-        // not slap at all
-        return characters.entities.asUnmodifiableObservableList();
+    public ObservableList<Entity> getAllList() {
+        return entities.getEntityList();
     }
+
+    public ObservableList<? extends Entity> getCharacterList() {
+        // not slap at all
+        return characters.getEntityList();
+    }
+
+    public ObservableList<? extends Entity> getItemList() {
+        return items.getEntityList();
+    }
+
+    public ObservableList<? extends Entity> getMobList() {
+        return mobs.getEntityList();
+    }
+
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/experimental/model/RerollAllEntities.java
+++ b/src/main/java/seedu/address/experimental/model/RerollAllEntities.java
@@ -1,0 +1,16 @@
+package seedu.address.experimental.model;
+
+import seedu.address.model.entity.Entity;
+
+/***/
+public class RerollAllEntities extends RerollEntities<Entity> {
+    /**
+     * Add all entities.
+     * @param lst
+     */
+    public void addAll(RerollEntities<? extends Entity> lst) {
+        for (Entity entity : lst.getEntityList()) {
+            entities.add(entity);
+        }
+    }
+}

--- a/src/main/java/seedu/address/experimental/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/experimental/model/util/SampleDataUtil.java
@@ -5,29 +5,40 @@ import java.util.HashSet;
 import seedu.address.experimental.model.ReadOnlyReroll;
 import seedu.address.experimental.model.Reroll;
 import seedu.address.model.entity.Character;
-import seedu.address.model.entity.Entity;
+import seedu.address.model.entity.Item;
 import seedu.address.model.entity.Mob;
 import seedu.address.model.entity.Name;
 import seedu.address.model.entity.Stats;
 import seedu.address.model.tag.Tag;
-
 /***/
 public class SampleDataUtil {
 
+    private static Character[] sampleCharacter;
+    private static Mob[] sampleMob;
+    private static Item[] sampleItem;
+
     /***/
-    public static Entity[] getSampleEntities() {
+    public static void getSampleEntities() {
         Character c = new Character(new Name("Item1"), new Stats(0, 0, 0), 3, 2, new HashSet<Tag>());
-        Mob m = new Mob(new Name("Mob1"), new Stats(300, 300, 300), 2, true, new HashSet<Tag>());
+        Mob m1 = new Mob(new Name("Mob1"), new Stats(300, 300, 300), 2, true, new HashSet<Tag>());
         Mob m2 = new Mob(new Name("Mob2"), new Stats(300, 300, 300), 2, true, new HashSet<Tag>());
-        Entity[] entities = {c, m, m2};
-        return entities;
+        sampleCharacter = new Character[] {c};
+        sampleMob = new Mob[] {m1, m2};
+        sampleItem = new Item[] {};
     }
 
     /***/
     public static ReadOnlyReroll getSampleReroll() {
         Reroll sampleRr = new Reroll();
-        for (Entity sampleEntity : getSampleEntities()) {
-            sampleRr.addEntity(sampleEntity);
+        getSampleEntities();
+        for (Item item : sampleItem) {
+            sampleRr.addItem(item);
+        }
+        for (Mob mob : sampleMob) {
+            sampleRr.addMob(mob);
+        }
+        for (Character character : sampleCharacter) {
+            sampleRr.addCharacter(character);
         }
         return sampleRr;
     }

--- a/src/main/java/seedu/address/experimental/storage/JsonSerializableReroll.java
+++ b/src/main/java/seedu/address/experimental/storage/JsonSerializableReroll.java
@@ -41,16 +41,16 @@ public class JsonSerializableReroll {
         Reroll reroll = new Reroll();
         // Add all mobs
         for (JsonAdaptedMob jsonMob : mobs) {
-            reroll.addEntity(jsonMob.toModelType());
+            reroll.addMob(jsonMob.toModelType());
         }
         // Add all characters
         for (JsonAdaptedCharacter jsonChar : characters) {
-            reroll.addEntity(jsonChar.toModelType());
+            reroll.addCharacter(jsonChar.toModelType());
         }
 
         // Add all items
         for (JsonAdaptedItem jsonItem : items) {
-            reroll.addEntity(jsonItem.toModelType());
+            reroll.addItem(jsonItem.toModelType());
         }
 
         return reroll;


### PR DESCRIPTION
Filtered list work as intended.
By default, shows all entitites within Reroll
After adding an entity of specific type, shows only entities of that specific type
Added support for listing entities of specific type with listItems(), listMobs()...
Possible to filter by predicates within the object type, by first changing to the specific filtered entitites, then passing in the predicate