### PR TITLE
Add filter command

### DIFF
--- a/src/main/java/seedu/address/experimental/model/Model.java
+++ b/src/main/java/seedu/address/experimental/model/Model.java
@@ -95,6 +95,12 @@ public interface Model {
     void updateFilteredEntityList(Predicate<Entity> predicate);
 
     /**
+     * Adds the predicate of the filtered entity list to filter by the given {@code predicate}.
+     *
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void addFilteredEntityList(Predicate<Entity> predicate);
+    /**
      * Resets filtered entity list back to all entities Can be used before tag/name find function
      */
     void resetFilteredEntityList();

--- a/src/main/java/seedu/address/experimental/model/ModelManager.java
+++ b/src/main/java/seedu/address/experimental/model/ModelManager.java
@@ -15,6 +15,7 @@ import seedu.address.model.entity.Character;
 import seedu.address.model.entity.Entity;
 import seedu.address.model.entity.Item;
 import seedu.address.model.entity.Mob;
+import seedu.address.model.util.ComposedPredicate;
 
 /**
  * Represents the in-memory model of the Reroll data.
@@ -160,6 +161,14 @@ public class ModelManager implements Model {
         requireNonNull(predicate);
         filteredActive.setPredicate(predicate);
     }
+
+    @Override
+    public void addFilteredEntityList(Predicate<Entity> predicate) {
+        requireNonNull(predicate);
+        filteredActive.setPredicate(new ComposedPredicate<>(filteredActive.getPredicate(), predicate));
+    }
+
+
 
     // Reset
     @Override

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.experimental.model.Model;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.tag.Tag;
+
+
+/**
+ * Filters all entities in the address book to the user according to the given tag.
+ */
+public class FilterCommand extends Command {
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_SUCCESS = "Filtered all entities";
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Filters the entities of a provided tag";
+
+    private List<String> tagList;
+
+    /**
+     * Saves the args to filter later
+     * @param asList
+     */
+    public FilterCommand(List<String> asList) {
+        requireNonNull(asList);
+        this.tagList = asList;
+    }
+
+    /**
+     * Executes the command and returns the result message.
+     *
+     * @param model {@code Model} which the command should operate on.
+     * @return feedback message of the operation result for display
+     * @throws CommandException If an error occurs during command execution.
+     */
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        model.addFilteredEntityList(entity -> true);
+        model.addFilteredEntityList(entity -> {
+            boolean result = true;
+            for (String tag : tagList) {
+                if (!entity.getTags().contains(new Tag(tag))) {
+                    result = false;
+                }
+            }
+
+            return result;
+        });
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -71,6 +72,8 @@ public class AddressBookParser {
 
         case ViewCommand.COMMAND_WORD:
             return new ViewCommand();
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser;
+
+import java.util.Arrays;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+
+/**
+ * Parses input arguments and creates a new FilterCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+
+    /**
+     * Parses {@code userInput} into a command and returns it.
+     *
+     * @param args
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    @Override
+    public FilterCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+
+        return new FilterCommand(Arrays.asList(nameKeywords));
+
+    }
+}

--- a/src/main/java/seedu/address/model/util/ComposedPredicate.java
+++ b/src/main/java/seedu/address/model/util/ComposedPredicate.java
@@ -1,0 +1,43 @@
+package seedu.address.model.util;
+
+import java.util.function.Predicate;
+
+/**
+ * Composes any number of predicates together.
+ * @param <T> the input type for predicates
+ */
+public class ComposedPredicate<T> implements Predicate<T> {
+
+    private Predicate<? super T> composedPredicate;
+
+
+    /**
+     * Creates a Predicate that is composed of the base and predicate vararg given.
+     * @param base the current predicate
+     * @param predicates predicate to compose with the base
+     */
+    public ComposedPredicate(Predicate<? super T> base, Predicate<T>... predicates) {
+        if (base != null) {
+            composedPredicate = base;
+        } else {
+            composedPredicate = input -> true;
+        }
+        for (Predicate<T> predicate : predicates) {
+            composedPredicate = predicate.and(composedPredicate);
+        }
+    }
+
+    /**
+     * Evaluates this predicate on the given argument.
+     *
+     * @param t the input argument
+     * @return {@code true} if the input argument matches the predicate,
+     *     otherwise {@code false}
+     */
+    @Override
+    public boolean test(T t) {
+        return composedPredicate.test(t);
+    }
+
+
+}


### PR DESCRIPTION
Currently, there is no way to view all entities of a certain tag.
This pr adds the filter command to accept a tag to show all entities of a tag. Multiple filters can be added together for more specific filtering

Closes #64 